### PR TITLE
fix: Notifications Without Permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />    
 
     <application
         android:name=".BalanceApp"


### PR DESCRIPTION
Fixes: #92
When targeting Android 13 or higher, posting a permission requires holding the POST_NOTIFICATIONS permission (usage from com.arr.bugsend.BugSendNotification)
