### PR TITLE
ci: arregla el workflow publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.repository_owner, 'suitetecsa') }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
ahora la creación de lanzamientos solo se lleva a cabo cuando se crea un nuevo tag
